### PR TITLE
Add Learning FROST link to index page

### DIFF
--- a/_pages/index.md
+++ b/_pages/index.md
@@ -113,6 +113,7 @@ _Blockchain Commons' specifications aren't built for any specific blockchain. (I
 
    * See our [Zcash page](/chains/zcash/)
    * See our [Learning Bitcoin from the Command Line repo](https://github.com/BlockchainCommons/Learning-Bitcoin-from-the-Command-Line/blob/master/README.md)
+   * See our [Learning FROST from the Command Line](https://learningfrost.blockchaincommons.com/)
 
 ## Other <font color="#888888">Future</font> Development
 


### PR DESCRIPTION
Added a link to the Learning FROST from the Command Line resource.

I know there is a big `Latest News` banner with this information but believe or not I missed when trying to check/search for the link.